### PR TITLE
Add requirement for docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Requirements:
 * web server with PHP (5.5+) support (if you don't have an existing setup, this can be satisfied with: `docker run --name nginx-measure -p 443:443 -p 80:80 -v /path/to/Measure/dashboard:/var/www/html -d boxedcode/alpine-nginx-php-fpm`
 * node 6.x.
 * git
+* docker-compose
 
 Check out ghcrawler and -cli:
 


### PR DESCRIPTION
It doesn't say you need docker-compose, and you do, and on a blank server, you won't have it.