### PR TITLE
change README to add sqlite DB volume to nginx server startup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A huge thank you to [Linux Fund](http://linuxfund.org/) for sponsoring the initi
 (most of these steps will get automated. But they aren't, yet.)
 
 Requirements:
-* web server with PHP (5.5+) support (if you don't have an existing setup, this can be satisfied with: `docker run --name nginx-measure -p 443:443 -p 80:80 -v /path/to/Measure/dashboard:/var/www/html -d boxedcode/alpine-nginx-php-fpm`
+* web server with PHP (5.5+) support (if you don't have an existing setup, this can be satisfied with: `docker run --name nginx-measure -p 443:443 -p 80:80 -v /path/to/Measure/dashboard:/var/www/html -v /path/to/Measure/database:/var/www/database -d boxedcode/alpine-nginx-php-fpm`
 * node 6.x.
 * git
 * docker-compose


### PR DESCRIPTION
With this change, users will have write access to the sqlite DB as long as they are using the docker setup for their server and are running it according to the README instructions.
 
This fix is a large part of #100, but it does not create an error message for other circumstances where the server/db might be set up incorrectly. 