### PR TITLE
Added start script to package.json to reflect memory limits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Clone this repo
 npm install # only need this the first time
 cp config.yaml.example config.yaml
 # edit config.yaml to contain your list of repositories
-node makedash.js
+npm start
 ```
 
 and your dashboard should be in `dashboard/index.js` (unless you changed that in config.yaml).

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "makedash.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon -e tmpl,js,css,yaml,php -i dashboard -i database makedash.js"
+    "dev": "nodemon -e tmpl,js,css,yaml,php -i dashboard -i database makedash.js",
+    "start": "node --max-old-space-size=8192 makedash.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This is a possible fix for #76. Using the `node --max-old-space-size=8192 makedash.js` command from the issue, I added a start script to the npm package.json file to start Node with the higher memory limit by default. This should eliminate memory space issues related to Node as 8 GB should be more than enough as opposed to Node's default 1.76 GB.

http://prestonparry.com/articles/IncreaseNodeJSMemorySize/

I also updated the ReadMe to reflect the new start command.