### PR TITLE
Update README to clarify the crawler start-up step

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Now, start up the crawler:
 cd ghcrawler
 npm install # you only need to do this the first time
 cd docker
-CRAWLER_GITHUB_TOKENS=<your github token> docker-compose up # this will take a while the first time because it downloads docker images
+CRAWLER_GITHUB_TOKENS=<your github token> docker-compose up # this will take a while the first time, because it downloads docker images (usually about 5-20 minutes)
+# When setup is done, the process won't terminate. Instead, when the crawler is up and running, you'll see log output from the crawler, in a continuous loop.
 ```
-
 and teach the crawler about your repositories:
 
 ```


### PR DESCRIPTION
The first time I ran this, the documentation just said that this step would take "a while". Being ignorant of how the crawler worked, since  I was still seeing log output for hours, I thought it was still setting up and wasted a day waiting for the start-up process to terminate :-O oops. This change would keep that from happening to anyone else.