### PR TITLE
Show all PRs for a repo, sorted by score

### DIFF
--- a/widgets/repo/40_attentionPRs.js
+++ b/widgets/repo/40_attentionPRs.js
@@ -23,14 +23,9 @@ module.exports = function(options, callback) {
         })
         scores.sort((b,a) => a.score - b.score);
 
-        // remove PRs that are too new
-        if (options.config.hoursToRespond) {
-            let htr = moment().add(-options.config.hoursToRespond, "hours");
-            scores = scores.filter((s) => { return s.created_moment < htr; })
-        }
         let result = {
-            title: "PRs that need attention",
-            list: scores.slice(0,5).map(pr => { 
+            title: "Open PRs sorted by urgency score (descending)",
+            list: scores.map(pr => {
                 return {html: '<a href="' + pr.pr.html_url + '">' + pr.pr.title + '</a>'}; 
             })
         }

--- a/widgets/repo/40_attentionPRs.js
+++ b/widgets/repo/40_attentionPRs.js
@@ -23,12 +23,27 @@ module.exports = function(options, callback) {
         })
         scores.sort((b,a) => a.score - b.score);
 
+        if (options.config.hoursToRespond) {
+            let htr = moment().subtract(options.config.hoursToRespond, "hours");
+            too_new = scores.filter((s) => { return s.created_moment >= htr; });
+            scores = scores.filter((s) => { return s.created_moment < htr; });
+        }
+
         let result = {
             title: "Open PRs sorted by urgency score (descending)",
             list: scores.map(pr => {
                 return {html: '<a href="' + pr.pr.html_url + '">' + pr.pr.title + '</a>'}; 
             })
         }
+
+        if (options.config.hoursToRespond) {
+            result.list.append({html: '<hr />'});
+            result.list.append({html: '<b>New PRs</b>'});
+            result.list = result.list.concat(too_new.map(pr => {
+                return {html: '<a href="' + pr.pr.html_url + '">' + pr.pr.title + '</a>'};
+            }))
+        }
+
         options.templates.list(result, callback);
     }).catch(e => { callback(e); });;
 }


### PR DESCRIPTION
One of the good things about Measure is that you can easily see contributions and PRs coming from external contributors.

I use the widget that shows "PRs that require attention" a lot, but it is a pity that it only shows 5 of them, as this is the best way to get a list of PRs coming from external contributors.

This PR changes that widget to show all PRs instead, but sorted by descending order of score, so the most urgent ones will still show at the top.