### PR TITLE
Bump sqllite3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "object.values": "^1.0.4",
     "plugin-system": "^0.2.1",
     "request": "^2.81.0",
-    "sqlite3": "^3.1.9",
+    "sqlite3": "^4.1.1",
     "stacktrace-js": "^2.0.0",
     "stacktrace-parser": "^0.1.4",
     "word-wrap": "^1.2.3"


### PR DESCRIPTION
Measure does not build unless newest version of sqllite3 is used