### PR TITLE
Alter how the zoom slider works

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -179,6 +179,16 @@ function expandGraph(node, graphdata) {
             graphtitle + " " + document.querySelector("nav h2").textContent,
         fontColor: "white"
     };
+    graphdata.options.Measure = { sliderPercentage: 50 };
+    var graphSlider = node.querySelector(".adjustable-graph-slider");
+    if (graphSlider) { graphdata.options.Measure.sliderPercentage = graphSlider.valueAsNumber; }
+    var chosenGraphTypeRadio = node.querySelector("input[type='radio']:checked");
+    if (chosenGraphTypeRadio) {
+        var lbl = node.querySelector("label[for='" + chosenGraphTypeRadio.id + "']");
+        if (lbl) {
+            graphdata.options.Measure.graphType = lbl.textContent;
+        }
+    }
     new Chart(cv, graphdata);
 }
 


### PR DESCRIPTION
Changing the zoom slider on a graph now attempts to set the graph to show a particular time period.
Switching graph type (Monthly to Weekly, for example) will attempt to, roughly, maintain that time period.
(It's not exact, but it's approximately correct.)
Showing a graph in fullscreen will also now respect both your current setting for the graph type (monthly/weekly) and also the current time period on the zoom slider.
This is issue #128.